### PR TITLE
feat: implement parser

### DIFF
--- a/op.go
+++ b/op.go
@@ -56,9 +56,9 @@ func NewOpWithOperand(c rune, operand uint) (Op, bool) {
 	case '.':
 		return Op{kind: OpOutput, operand: operand}, true
 	case '[':
-		return Op{kind: OpJumpFwd, operand: 0}, true
+		return Op{kind: OpJumpFwd, operand: operand}, true
 	case ']':
-		return Op{kind: OpJumpBack, operand: 0}, true
+		return Op{kind: OpJumpBack, operand: operand}, true
 	default:
 		return Op{}, false
 	}

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,57 @@
+package bfgo
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+)
+
+func Parse(reader *bufio.Reader) ([]Op, error) {
+	ops := make([]Op, 0, 256)
+	stack := make([]int, 0, 32)
+
+	lexer := NewLexer(reader)
+
+	for {
+		op, err := lexer.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+
+		switch op.kind {
+		case OpJumpFwd:
+			stack = append(stack, len(ops))
+			ops = append(ops, op)
+
+		case OpJumpBack:
+			if len(stack) == 0 {
+				return nil, fmt.Errorf("unmatched ']' at operation %d", len(ops))
+			}
+
+			// pop from stack
+			openPos := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+
+			ops[openPos].operand = uint(len(ops))
+
+			jumpBackOp, ok := NewOpWithOperand(']', uint(openPos))
+			if !ok {
+				return nil, fmt.Errorf("failed to create jump back operation at position %d", len(ops))
+			}
+
+			ops = append(ops, jumpBackOp)
+
+		default:
+			ops = append(ops, op)
+		}
+	}
+
+	if len(stack) != 0 {
+		return nil, fmt.Errorf("unmatched '[' at operation %d", stack[len(stack)-1])
+	}
+
+	return ops, nil
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -73,6 +73,14 @@ func TestParserNestedBrackets(t *testing.T) {
 	if ops[1].operand != 3 {
 		t.Errorf("expected inner JumpFwd operand to be 3, got %d", ops[1].operand)
 	}
+
+	if ops[3].operand != 1 {
+		t.Errorf("expected inner JumpBack operand to be 1, got %d", ops[3].operand)
+	}
+
+	if ops[4].operand != 0 {
+		t.Errorf("expected outer JumpBack operand to be 0, got %d", ops[4].operand)
+	}
 }
 
 func TestParserUnmatchedOpenBracket(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,0 +1,92 @@
+package bfgo
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParser(t *testing.T) {
+	source, err := os.Open(filepath.Join("testdata", "helloworld.bf"))
+	if err != nil {
+		t.Fatalf("failed to open source file: %v", err)
+	}
+	defer source.Close()
+
+	ops, err := Parse(bufio.NewReader(source))
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	if len(ops) != 68 {
+		t.Errorf("expected 68 operations, got %d", len(ops))
+	}
+}
+
+func TestParserMatchedBrackets(t *testing.T) {
+	input := "[+]"
+	ops, err := Parse(bufio.NewReader(strings.NewReader(input)))
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	if len(ops) != 3 {
+		t.Fatalf("expected 3 operations, got %d", len(ops))
+	}
+
+	// ops[0] should be JumpFwd pointing to ops[2]
+	if ops[0].kind != OpJumpFwd {
+		t.Errorf("expected OpJumpFwd at position 0, got %s", ops[0].String())
+	}
+	if ops[0].operand != 2 {
+		t.Errorf("expected JumpFwd operand to be 2, got %d", ops[0].operand)
+	}
+
+	// ops[2] should be JumpBack pointing to ops[0]
+	if ops[2].kind != OpJumpBack {
+		t.Errorf("expected OpJumpBack at position 2, got %s", ops[2].String())
+	}
+	if ops[2].operand != 0 {
+		t.Errorf("expected JumpBack operand to be 0, got %d", ops[2].operand)
+	}
+}
+
+func TestParserNestedBrackets(t *testing.T) {
+	input := "[[+]]"
+	ops, err := Parse(bufio.NewReader(strings.NewReader(input)))
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	if len(ops) != 5 {
+		t.Fatalf("expected 5 operations, got %d", len(ops))
+	}
+
+	// ops[0] should be JumpFwd pointing to ops[4]
+	if ops[0].operand != 4 {
+		t.Errorf("expected outer JumpFwd operand to be 4, got %d", ops[0].operand)
+	}
+
+	// ops[1] should be JumpFwd pointing to ops[3]
+	if ops[1].operand != 3 {
+		t.Errorf("expected inner JumpFwd operand to be 3, got %d", ops[1].operand)
+	}
+}
+
+func TestParserUnmatchedOpenBracket(t *testing.T) {
+	input := "[++"
+	_, err := Parse(bufio.NewReader(strings.NewReader(input)))
+	if err == nil {
+		t.Fatalf("expected error for unmatched '[', got nil")
+	}
+}
+
+func TestParserUnmatchedCloseBracket(t *testing.T) {
+	input := "++]"
+	_, err := Parse(bufio.NewReader(strings.NewReader(input)))
+	if err == nil {
+		t.Fatalf("expected error for unmatched ']', got nil")
+	}
+}


### PR DESCRIPTION
This pull request introduces a new parser for the `bfgo` package, along with comprehensive tests to ensure correct parsing of Brainfuck code, especially around bracket matching and nesting.

Parser implementation:

* Added a new `Parse` function in `parser.go` that reads Brainfuck source code, converts it into a list of operations (`Op`), and handles matching of `[` and `]` brackets, including error reporting for unmatched brackets.

Parser tests:

* Added `parser_test.go` with tests covering:
  - Parsing a real Brainfuck program (`helloworld.bf`) and checking operation count.
  - Correct handling of matched and nested brackets, ensuring jump operations point to the correct positions.
  - Error detection for unmatched opening and closing brackets.

Closes #2 