### PR TITLE
chore: update go version to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module bfgo
 
-go 1.25.3
+go 1.26


### PR DESCRIPTION
This pull request makes a minor update to the Go version specified in the `go.mod` file, increasing it from 1.25.3 to 1.26.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line tooling change; main risk is CI/build failures if environments aren’t yet on Go 1.26.
> 
> **Overview**
> Updates the module’s `go.mod` to require Go `1.26` (from `1.25.3`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36b6cb176536640b5233baef02d418a2ee28a7ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->